### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@
 
 A powerful Model Context Protocol (MCP) server that provides webhook notification capabilities to AI agents and LLM applications. Send rich notifications to Discord and Slack with automatic service detection, retry logic, and comprehensive security features.
 
+<a href="https://glama.ai/mcp/servers/@thesammykins/notifyme_mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@thesammykins/notifyme_mcp/badge" alt="notify_me_mcp MCP server" />
+</a>
+
 ## ✨ Features
 
 - 🔧 **Three MCP Tools**: `send_notification`, `validate_webhook`, `list_services`


### PR DESCRIPTION
This PR adds a badge for the [notify_me_mcp](https://glama.ai/mcp/servers/@thesammykins/notifyme_mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@thesammykins/notifyme_mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@thesammykins/notifyme_mcp/badge" alt="notify_me_mcp MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.